### PR TITLE
add explicit cast to silence error with Xcode 15.4

### DIFF
--- a/include/boost/mmap/mapping/posix/mapping.hpp
+++ b/include/boost/mmap/mapping/posix/mapping.hpp
@@ -56,7 +56,7 @@ struct mapping
 
 #ifdef PAGE_SIZE
 #   ifdef __APPLE__
-inline std::uint32_t const page_size{ PAGE_SIZE }; // Not a constant expression on Apple platform
+inline std::uint32_t const page_size{ static_cast<uint32_t>(PAGE_SIZE) }; // Not a constant expression on Apple platform
 #   else
 constexpr std::uint32_t const page_size{ PAGE_SIZE }; // Under Emscripten PAGE_SIZE is 64k/does not fit into a std::uint16_t
 #endif


### PR DESCRIPTION
Sonoma 14.6 + Xcode 15.4 throws an error while building. The fix was generate by Xcode and the project is building fine with it. 